### PR TITLE
changes on middleware ->only processes that last longer than 5 second…

### DIFF
--- a/app/middleware/logging_middleware.go
+++ b/app/middleware/logging_middleware.go
@@ -18,6 +18,9 @@ func (l *LoggerMiddleware) Logger() gin.HandlerFunc {
 
 		// after request
 		latency := time.Since(t)
-		log.Printf("Letency: %s", latency)
+		// only processes that last longer than 5 seconds will be written in the log.
+		if latency.Seconds() > 5 {
+			log.Printf("Letency: %v", latency)
+		}
 	}
 }


### PR DESCRIPTION
only processes that last longer than 5 seconds will be written in the log.